### PR TITLE
Add Claude PR Assistant workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow that runs the Claude Code assistant on issues and pull request comments or reviews mentioning '@claude'.

CI:
- Add .github/workflows/claude.yml to trigger the Claude Code action on issue_comment, pull_request_review_comment, pull_request_review, and issues events
- Restrict execution to events containing '@claude' in the comment body or issue title/body
- Checkout the repository and invoke anthropics/claude-code-action@beta using the ANTHROPIC_API_KEY secret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new GitHub Actions workflow that responds to "@claude" mentions in issues, pull requests, and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->